### PR TITLE
Liticed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Map file types to modules which provide a [require.extensions] loader.
   '.coffee.md': ['coffee-script/register', 'coffee-script'],
   '.csv': 'require-csv',
   '.iced': ['iced-coffee-script/register', 'iced-coffee-script'],
-  '.iced.md': ['iced-coffee-script/register', 'iced-coffee-script'],
+  '.iced.md': 'iced-coffee-script/register',
   '.ini': 'require-ini',
   '.js': null,
   '.json': null,
@@ -38,7 +38,7 @@ Map file types to modules which provide a [require.extensions] loader.
   '.jsx': [
     {
       module: 'babel/register',
-      function (module) {
+      register: function (module) {
         module({
           extensions: '.jsx'
         });
@@ -55,7 +55,7 @@ Map file types to modules which provide a [require.extensions] loader.
     }
   ],
   '.litcoffee': ['coffee-script/register', 'coffee-script'],
-  '.liticed': ['iced-coffee-script/register', 'iced-coffee-script'],
+  '.liticed': 'iced-coffee-script/register',
   '.ls': ['livescript', 'LiveScript'],
   '.node': null,
   '.toml': {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const extensions = {
   '.coffee.md': ['coffee-script/register', 'coffee-script'],
   '.csv': 'require-csv',
   '.iced': ['iced-coffee-script/register', 'iced-coffee-script'],
-  '.iced.md': ['iced-coffee-script/register', 'iced-coffee-script'],
+  '.iced.md': 'iced-coffee-script/register',
   '.ini': 'require-ini',
   '.js': null,
   '.json': null,
@@ -41,7 +41,7 @@ const extensions = {
     }
   ],
   '.litcoffee': ['coffee-script/register', 'coffee-script'],
-  '.liticed': ['iced-coffee-script/register', 'iced-coffee-script'],
+  '.liticed': 'iced-coffee-script/register',
   '.ls': ['livescript', 'LiveScript'],
   '.node': null,
   '.toml': {


### PR DESCRIPTION
literate iced-coffee-script was not supported until after they made the `register` module available, so I removed it from the fallback.  Also updated the readme.