### PR TITLE
support babel-core - closes #29

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,24 @@
 const extensions = {
-  '.babel.js': {
-    module: 'babel/register',
-    register: function (module) {
-      module({
-        // register on .js extension due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
-        // which only captures the final extension (.babel.js -> .js)
-        extensions: '.js'
-      })
+  '.babel.js': [
+    {
+      module: 'babel-core/register',
+      register: function (module) {
+        module({
+          // register on .js extension due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
+          // which only captures the final extension (.babel.js -> .js)
+          extensions: '.js'
+        });
+      }
+    },
+    {
+      module: 'babel/register',
+      register: function (module) {
+        module({
+          extensions: '.js'
+        });
+      }
     }
-  },
+  ],
   '.cirru': 'cirru-script/lib/register',
   '.cjsx': 'node-cjsx/register',
   '.co': 'coco',
@@ -22,6 +32,14 @@ const extensions = {
   '.json': null,
   '.json5': 'json5/lib/require',
   '.jsx': [
+    {
+      module: 'babel-core/register',
+      register: function (module) {
+        module({
+          extensions: '.jsx'
+        });
+      }
+    },
     {
       module: 'babel/register',
       register: function (module) {


### PR DESCRIPTION
#### What's this PR do?
Adds support for (and defaults to) `babel-core` module for `.babel.js` and `.jsx` extensions.

#### Where should the reviewer start?
`index.js` is where everything happens.

#### How should this be manually tested?
Link this into a gulp project and attempt to use `babel-core` as the loader.

#### Any background context you want to provide?
Nope.

#### What are the relevant tickets?
Closes #29 
