### PR TITLE
Added `typescript-node` for TS 1.5 compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Map file types to modules which provide a [require.extensions] loader.
       module.install();
     }
   },
-  '.ts': ['typescript-register', 'typescript-require'],
+  '.ts': ['typescript-node/register', 'typescript-register', 'typescript-require'],
+  '.tsx': ['typescript-node/register'],
   '.wisp': 'wisp/engine/node',
   '.xml': 'require-xml',
   '.yaml': 'require-yaml',

--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ const extensions = {
       module.install();
     }
   },
-  '.ts': ['typescript-register', 'typescript-require'],
+  '.ts': ['typescript-node/register', 'typescript-register', 'typescript-require'],
+  '.tsx': ['typescript-node/register'],
   '.wisp': 'wisp/engine/node',
   '.xml': 'require-xml',
   '.yaml': 'require-yaml',


### PR DESCRIPTION
I just tried using TypeScript with Gulp and found it uses this module. I haven't had any luck with the other TypeScript node runners out there and want to be able to compile using the latest version of TypeScript, so I've added `typescript-node` (which I wrote) to the array of TypeScript compilers. Not sure on the what the proper etiquette is so I've left the rest alone.

Should I also look at adding some tests?